### PR TITLE
Corrected `opts.basedir` when using available file contents.

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const intoStream = require('into-stream')
 const through2 = require('through2')
 const gutil = require('gulp-util')
 const concat = require('concat-stream')
+const path = require('path')
 
 const bundlers = {}
 
@@ -54,7 +55,7 @@ function transform(opts) {
  */
 function createBundler(opts, file, transform) {
   opts.entries = file.isNull() ? file.path : intoStream(file.contents)
-  opts.basedir = 'string' !== typeof opts.entries ? file.base : undefined
+  opts.basedir = 'string' !== typeof opts.entries ? path.dirname(file.path) : undefined
 
   let bundler = bundlers[file.path]
 

--- a/test/fixtures/modules/d/e/f.js
+++ b/test/fixtures/modules/d/e/f.js
@@ -1,0 +1,1 @@
+module.exports = require('../../../a+b');

--- a/test/task.js
+++ b/test/task.js
@@ -18,7 +18,7 @@ test.cb('bundle a file', t => {
 })
 
 test.cb('take file contents when available', t => {
-  vfs.src('fixtures/a+b.js')
+  vfs.src('fixtures/modules/d/e/f.js')
     .pipe(bro())
     .pipe(assert.length(1))
     .pipe(assert.first(


### PR DESCRIPTION
When using a deeply nested file as the entry point, `file.base` was giving the wrong value for `opts.basedir`. This caused browserify to throw relative path errors. Changing it to use `path.dirname(file.path)` corrected the issue.