### PR TITLE
No longer emit logs, issue #6

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,6 @@ function createBundler(opts, file, transform) {
     bundlers[file.path] = bundler
   }
 
-  bundler.on('log', log)
   bundler.on('log', message => transform.emit('log', message))
   bundler.on('time', time => transform.emit('time', time))
 


### PR DESCRIPTION
I have been using gulp-bro for a while now and created https://github.com/ngryman/gulp-bro/issues/6.

I was just looking for where the log was coming from and it seems to be from 'browserify-incremental'. It doesn't look like anything useful actually gets logged here in this case and if people want to listen to the logs they can still do.

```js
.pipe(bro(...))
.on('log', ...)
```

As far as I can tell so I opted to just remove the line.
Let me know if there is preferred way you would like to handle this.